### PR TITLE
Update 36463_bug.cos

### DIFF
--- a/36463_bug.cos
+++ b/36463_bug.cos
@@ -25,7 +25,7 @@ scrp 2 13 36463 1000
 	else
 		kill targ
 	endi
-	tick 1
+	tick 8
 endm
 
 **


### PR DESCRIPTION
change tick 1 (1/20th of a second) to tick 8 (just less than half a second).  Most C3 animals use tick 8 and it's probably kinder to the engine to keep it as high as possible.